### PR TITLE
Add support for SLES

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,13 +87,26 @@ class nrpe::params {
       $nrpe_user        = 'nagios'
       $nrpe_group       = 'nagios'
       $nrpe_pid_file    = '/var/run/nrpe/nrpe.pid'
-      $nrpe_config      = '/etc/nrpe.cfg'
-      $nrpe_include_dir = '/etc/nrpe.d/'
       $nrpe_service     = 'nrpe'
-      $nrpe_packages    = [
-        'nrpe',
-        'nagios-plugins-all',
-      ]
+      case $::operatingsystem {
+        'SLES': {
+          $nrpe_config      = '/etc/nagios/nrpe.cfg'
+          $nrpe_include_dir = '/etc/nagios/nrpe.d/'
+          $nrpe_packages    = [
+            'nagios-nrpe',
+            'nagios-plugins',
+            'nagios-plugins-nrpe',
+          ]
+        }
+        default:   {
+          $nrpe_config      = '/etc/nrpe.cfg'
+          $nrpe_include_dir = '/etc/nrpe.d/'
+          $nrpe_packages    = [
+            'nrpe',
+            'nagios-plugins-all',
+          ]
+        }
+      }
     }
     'OpenBSD': {
       $libdir           = '/usr/local/libexec/nagios'


### PR DESCRIPTION
I have put a case statement for the operatingsystem below the Suse case of the osfamily. 
At least this makes the nrpe stuff work for me on SLES 11 SP3, and as far as I could see, directory layout is the same on SLES11 SP1 too, so I think it should work on all SLES11 versions.