### PR TITLE
Improved plugin class with 'content' and 'mode' attributes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,8 @@ class nrpe::params {
     default   => 'root',
   }
 
+  $nrpe_plugin_file_mode = '0755'
+
   case $::osfamily {
     'Debian':  {
       $libdir           = '/usr/lib/nagios/plugins'

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -3,6 +3,7 @@ define nrpe::plugin (
   $ensure       = present,
   $content      = undef,
   $source       = undef,
+  $mode         = $nrpe::params::nrpe_plugin_file_mode,
   $libdir       = $nrpe::params::libdir,
   $package_name = $nrpe::params::nrpe_packages,
   $file_group   = $nrpe::params::nrpe_files_group,
@@ -13,7 +14,7 @@ define nrpe::plugin (
     source  => $source,
     owner   => 'root',
     group   => $file_group,
-    mode    => '0755',
+    mode    => $mode,
     require => Package[$package_name],
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,13 +1,15 @@
 #
 define nrpe::plugin (
   $ensure       = present,
-  $source       = false,
+  $content      = undef,
+  $source       = undef,
   $libdir       = $nrpe::params::libdir,
   $package_name = $nrpe::params::nrpe_packages,
   $file_group   = $nrpe::params::nrpe_files_group,
 ) {
   file { "${libdir}/${title}":
     ensure  => $ensure,
+    content => $content,
     source  => $source,
     owner   => 'root',
     group   => $file_group,


### PR DESCRIPTION
Improvements for the ```nrpe::plugin``` class.

* Added support for the 'content' attribute for a plugin
* Added support to set file mode of plugin file

```puppet
nrpe::plugin { 'plugin':
  content => template('template.erb'),
  mode    => '0700'
}
```