### PR TITLE
Take the parameters given to the module into account, rather than

### DIFF
--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -2,10 +2,10 @@
 define nrpe::command (
   $command,
   $ensure       = present,
-  $include_dir  = $nrpe::params::nrpe_include_dir,
+  $include_dir  = $nrpe::include_dir,
+  $package_name = $nrpe::package_name,
+  $service_name = $nrpe::service_name,
   $libdir       = $nrpe::params::libdir,
-  $package_name = $nrpe::params::nrpe_packages,
-  $service_name = $nrpe::params::nrpe_service,
   $file_group   = $nrpe::params::nrpe_files_group,
   $sudo         = false,
 ) {


### PR DESCRIPTION
the defaults from the params.pp when creating commands.

I was testing with a newer version of nagios/nrpe etc on SLES, so I had to set the package_name array parameter to the NRPE module. When Puppet came to create the commands, I got:

Warning: The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.
   (at /usr/lib64/ruby/vendor_ruby/1.8/puppet/type/package.rb:430:in `default')

because the command.pp took the defaults from the params.pp into account, instead of the parameters given to init.pp.

Instead of only changing the package_name parameter, I updated all parameters to the type that are able to changed by the user via init.pp.

let me know if there is something wrong or needs enhancement etc. and I'm happy to do.

cheers,