### PR TITLE
nrpe::include_dir does not function as suggested.

### DIFF
--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -252,5 +252,5 @@ connection_timeout=<%= @connection_timeout %>
 # you can place your config snipplets into nrpe.d/
 # only snipplets ending in .cfg will get included
 #include_dir=/etc/nagios/nrpe.d/
-include_dir=<%= @nrpe_include_dir %>
+include_dir=<%= @include_dir %>
 


### PR DESCRIPTION

The template uses nrpe_include_dir. When using the below override, the directory is created, however the config file is not updated.

class {'nrpe':
	include_dir => '/path/to/dir/',
}

The updated template allows the use of the above, whilst still retaining the default settings.