### PR TITLE
Fix package provider attribute variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class nrpe (
 
   package { $package_name:
     ensure   => installed,
-    provider => $nrpe::params::provider,
+    provider => $provider,
   }
 
   service { 'nrpe_service':


### PR DESCRIPTION
This commit causes the package resource to refer to the correct
source for the value of its provider attribute. Previously it
referred to a variable that didn't exist.

This closes #38
