### PR TITLE
Use variable for title of service resource to be consistent.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class nrpe (
     }
   }
 
-  service { 'nrpe_service':
+  service { $service_name:
     ensure    => running,
     name      => $service_name,
     enable    => true,

--- a/spec/classes/nrpe_spec.rb
+++ b/spec/classes/nrpe_spec.rb
@@ -6,9 +6,10 @@ describe 'nrpe' do
     { osfamily: 'RedHat' }
   end
 
+  it { is_expected.to compile.with_all_deps }
   it { should contain_package('nrpe').with_ensure('installed') }
   it { should contain_package('nagios-plugins-all').with_ensure('installed') }
-  it { should contain_service('nrpe_service').with_ensure('running') }
+  it { should contain_service('nrpe').with_ensure('running') }
   it { should contain_file('nrpe_config') }
   it { should contain_file('nrpe_include_dir').with_ensure('directory') }
 

--- a/spec/defines/command_spec.rb
+++ b/spec/defines/command_spec.rb
@@ -16,5 +16,6 @@ describe 'nrpe::command', :type => :define do
       }
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { should contain_file('/etc/nagios/nrpe.d/check_users.cfg') }
 end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -15,5 +15,6 @@ describe 'nrpe::plugin', :type => :define do
       }
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { should contain_file('/usr/lib/nagios/plugins/check_users') }
 end


### PR DESCRIPTION
This now works with rspec checking that the catalog compiles. This was actually working with puppet which appears to be able to find the service resource based on the name parameter. However this change makes the implementation consistent with the package resource above.