### PR TITLE
Support for changing file mode of Nagios commands that contain secrets

### DIFF
--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -2,6 +2,7 @@
 define nrpe::command (
   $command,
   $ensure       = present,
+  $mode         = $nrpe::params::nrpe_command_file_mode,
   $include_dir  = $nrpe::include_dir,
   $package_name = $nrpe::package_name,
   $service_name = $nrpe::service_name,
@@ -15,7 +16,7 @@ define nrpe::command (
     content => template('nrpe/command.cfg.erb'),
     owner   => 'root',
     group   => $file_group,
-    mode    => '0644',
+    mode    => $mode,
     require => Package[$package_name],
     notify  => Service[$service_name],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class nrpe::params {
   }
 
   $nrpe_plugin_file_mode = '0755'
+  $nrpe_command_file_mode = '0644'
 
   case $::osfamily {
     'Debian':  {


### PR DESCRIPTION
_i.e._ a user that needs to include a hardcode password in their nagios command could set file mode `0640`
