### PR TITLE
SSL support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,19 @@ class nrpe (
   $nrpe_user       = $nrpe::params::nrpe_user,
   $nrpe_group      = $nrpe::params::nrpe_group,
   $nrpe_pid_file   = $nrpe::params::nrpe_pid_file,
+  $nrpe_ssl_dir    = $nrpe::params::nrpe_ssl_dir,
+  $ssl_cert_file_content       = undef,
+  $ssl_privatekey_file_content = undef,
+  $ssl_cacert_file_content     = undef,
+  $ssl_version                 = $nrpe::params::ssl_version,
+  $ssl_ciphers                 = $nrpe::params::ssl_ciphers,
+  $ssl_client_certs            = $nrpe::params::ssl_client_certs,
+  $ssl_log_startup_params      = false,
+  $ssl_log_remote_ip           = false,
+  $ssl_log_protocol_version    = false,
+  $ssl_log_cipher              = false,
+  $ssl_log_client_cert         = false,
+  $ssl_log_client_cert_details = false,
 ) inherits nrpe::params {
 
   if $manage_package {
@@ -61,6 +74,39 @@ class nrpe (
     name    => $config,
     content => template('nrpe/nrpe.cfg.erb'),
     require => File['nrpe_include_dir'],
+  }
+
+  if $ssl_cert_file_content {
+    file { $nrpe_ssl_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => $nrpe_group,
+      mode   => '0750',
+    }
+    file { "${nrpe_ssl_dir}/ca-cert.pem":
+      ensure  => file,
+      owner   => 'root',
+      group   => $nrpe_group,
+      mode    => '0640',
+      content => $ssl_cacert_file_content,
+      notify  => Service[$service_name],
+    }
+    file { "${nrpe_ssl_dir}/nrpe-cert.pem":
+      ensure  => file,
+      owner   => 'root',
+      group   => $nrpe_group,
+      mode    => '0640',
+      content => $ssl_cert_file_content,
+      notify  => Service[$service_name],
+    }
+    file { "${nrpe_ssl_dir}/nrpe-key.pem":
+      ensure  => file,
+      owner   => 'root',
+      group   => $nrpe_group,
+      mode    => '0640',
+      content => $ssl_privatekey_file_content,
+      notify  => Service[$service_name],
+    }
   }
 
   file { 'nrpe_include_dir':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class nrpe::params {
       $nrpe_group       = 'nagios'
       $nrpe_pid_file    = '/var/run/nagios/nrpe.pid'
       $nrpe_config      = '/etc/nagios/nrpe.cfg'
+      $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
       $nrpe_include_dir = '/etc/nagios/nrpe.d'
       $nrpe_service     = 'nagios-nrpe-server'
       $nrpe_packages    = [
@@ -33,6 +34,7 @@ class nrpe::params {
       $nrpe_group       = 'nagios'
       $nrpe_pid_file    = '/var/run/nrpe.pid'
       $nrpe_config      = '/etc/opt/csw/nrpe.cfg'
+      $nrpe_ssl_dir     = '/etc/opt/csw/nrpe-ssl'
       $nrpe_include_dir = '/etc/opt/csw/nrpe.d'
       $nrpe_service     = 'cswnrpe'
       $nrpe_packages    = [
@@ -49,6 +51,7 @@ class nrpe::params {
       $nrpe_group       = 'nrpe'
       $nrpe_pid_file    = '/var/run/nrpe/nrpe.pid'
       $nrpe_config      = '/etc/nagios/nrpe.cfg'
+      $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
       $nrpe_include_dir = '/etc/nrpe.d'
       $nrpe_service     = 'nrpe'
       $nrpe_packages    = [
@@ -62,6 +65,7 @@ class nrpe::params {
       $nrpe_group       = 'nagios'
       $nrpe_pid_file    = '/var/run/nrpe2/nrpe2.pid'
       $nrpe_config      = '/usr/local/etc/nrpe.cfg'
+      $nrpe_ssl_dir     = '/usr/local/etc/nrpe-ssl'
       $nrpe_include_dir = '/usr/local/etc/nrpe.d'
       $nrpe_service     = 'nrpe2'
       $nrpe_packages    = [
@@ -75,6 +79,7 @@ class nrpe::params {
       $nrpe_group       = '_nrpe'
       $nrpe_pid_file    = '/var/run/nrpe/nrpe.pid'
       $nrpe_config      = '/etc/nrpe.cfg'
+      $nrpe_ssl_dir     = '/etc/nrpe-ssl'
       $nrpe_include_dir = '/etc/nrpe.d'
       $nrpe_service     = 'nrpe'
       $nrpe_packages    = [
@@ -91,6 +96,7 @@ class nrpe::params {
       case $::operatingsystem {
         'SLES': {
           $nrpe_config      = '/etc/nagios/nrpe.cfg'
+          $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
           $nrpe_include_dir = '/etc/nagios/nrpe.d'
           $nrpe_packages    = [
             'nagios-nrpe',
@@ -100,6 +106,7 @@ class nrpe::params {
         }
         default:   {
           $nrpe_config      = '/etc/nrpe.cfg'
+          $nrpe_ssl_dir     = '/etc/nrpe-ssl'
           $nrpe_include_dir = '/etc/nrpe.d'
           $nrpe_packages    = [
             'nrpe',
@@ -117,6 +124,7 @@ class nrpe::params {
       $nrpe_group       = 'nagios'
       $nrpe_pid_file    = '/var/run/nrpe.pid'
       $nrpe_config      = '/etc/nagios/nrpe.cfg'
+      $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
       $nrpe_include_dir = '/etc/nagios/nrpe.d'
       $nrpe_service     = 'nrpe'
       $nrpe_packages    = [
@@ -135,4 +143,15 @@ class nrpe::params {
   $command_prefix                  = undef
   $debug                           = 0
   $connection_timeout              = 300
+
+  $ssl_version                 = 'TLSv1.2+'
+  $ssl_ciphers                 = [
+    'DHE-RSA-AES128-GCM-SHA256',
+    'DHE-RSA-AES256-GCM-SHA384',
+    'DHE-RSA-AES128-SHA',
+    'DHE-RSA-AES256-SHA',
+    'DHE-RSA-AES128-SHA256',
+    'DHE-RSA-AES256-SHA256',
+  ]
+  $ssl_client_certs            = 1
 }

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -185,7 +185,66 @@ connection_timeout=<%= @connection_timeout %>
 
 #allow_weak_random_seed=1
 
+<%- if @ssl_cert_file_content -%>
+# SSL/TLS OPTIONS
+# These directives allow you to specify how to use SSL/TLS.
 
+# SSL VERSION
+# This can be any of: SSLv2 (only use SSLv2), SSLv2+ (use any version),
+#        SSLv3 (only use SSLv3), SSLv3+ (use SSLv3 or above), TLSv1 (only use
+#        TLSv1), TLSv1+ (use TLSv1 or above), TLSv1.1 (only use TLSv1.1),
+#        TLSv1.1+ (use TLSv1.1 or above), TLSv1.2 (only use TLSv1.2),
+#        TLSv1.2+ (use TLSv1.2 or above)
+# If an "or above" version is used, the best will be negotiated. So if both
+# ends are able to do TLSv1.2 and use specify SSLv2, you will get TLSv1.2.
+# If you are using openssl 1.1.0 or above, the SSLv2 options are not available.
+
+ssl_version=<%= @ssl_version %>
+
+# SSL CIPHER LIST
+# This lists which ciphers can be used. For backward compatibility, this
+# defaults to 'ssl_cipher_list=ALL:!MD5:@STRENGTH' in this version but
+# will be changed to something like the example below in a later version of NRPE.
+
+#ssl_cipher_list=ALL:!MD5:@STRENGTH
+#ssl_cipher_list=ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!RC4:!MD5:@STRENGTH
+ssl_cipher_list=<%= @ssl_ciphers.join(':') %>
+
+# SSL Certificate and Private Key Files
+
+ssl_cacert_file=<%= @nrpe_ssl_dir%>/ca-cert.pem
+ssl_cert_file=<%= @nrpe_ssl_dir%>/nrpe-cert.pem
+ssl_privatekey_file=<%= @nrpe_ssl_dir%>/nrpe-key.pem
+
+# SSL USE CLIENT CERTS
+# This options determines client certificate usage.
+# Values: 0 = Don't ask for or require client certificates (default)
+#         1 = Ask for client certificates
+#         2 = Require client certificates
+
+ssl_client_certs=<%= @ssl_client_certs %>
+
+# SSL LOGGING
+# This option determines which SSL messages are send to syslog. OR values
+# together to specify multiple options.
+
+# Values: 0x00 (0)  = No additional logging (default)
+#         0x01 (1)  = Log startup SSL/TLS parameters
+#         0x02 (2)  = Log remote IP address
+#         0x04 (4)  = Log SSL/TLS version of connections
+#         0x08 (8)  = Log which cipher is being used for the connection
+#         0x10 (16) = Log if client has a certificate
+#         0x20 (32) = Log details of client's certificate if it has one
+#         -1 or 0xff or 0x2f = All of the above
+<%- ssl_logging = 0 -%>
+<%- ssl_logging += 1 if @ssl_log_startup_params -%>
+<%- ssl_logging += 2 if @ssl_log_remote_ip -%>
+<%- ssl_logging += 4 if @ssl_log_protocol_version -%>
+<%- ssl_logging += 8 if @ssl_log_cipher -%>
+<%- ssl_logging += 16 if @ssl_log_client_cert -%>
+<%- ssl_logging += 32 if @ssl_log_client_cert_details -%>
+ssl_logging=<%= sprintf("0x%02x", ssl_logging) %>
+<%- end -%>
 
 # INCLUDE CONFIG FILE
 # This directive allows you to include definitions from an external config file.


### PR DESCRIPTION
Introduces several new parameters for configuring SSL.  This is only
tested on EL7, but is fully backwards compatible.  There are no changes
if the `ssl_cert_file_content` parameter is not specified.